### PR TITLE
Reserve cuTTLefishFip board

### DIFF
--- a/whoami.yml
+++ b/whoami.yml
@@ -181,3 +181,9 @@ devices:
     copyright: AllenNeuralDynamics
     repositoryUrl: https://github.com/AllenNeuralDynamics/harp.device.environment-sensor
     projectUrl: https://github.com/AllenNeuralDynamics/harp.device.environment-sensor
+  1407:
+    name: cuTTLefishFip
+    authors: AllenNeuralDynamics
+    copyright: AllenNeuralDynamics
+    repositoryUrl: https://github.com/AllenNeuralDynamics/harp.device.cuttlefish-fip
+    projectUrl: https://github.com/AllenNeuralDynamics/harp.device.cuttlefish-fip


### PR DESCRIPTION
This PR reserves the WhoAmI for the new cuTTLefishFip board.

This board is an interesting case where, similarly to the input/output expander, uses a previously registered board (cuTTLefish: 1403) hardware with a totally different firmware implementation. As a result, these two implementations will be considered as totally separate devices from the point of view of the protocol. They will live in separate repositories, versioned independely and asynchronously and will thus reserve different WhoAmI.

This board will be used to implement a generic laser/led + camera trigger protocol that allows collection of fiber photometry data.