### PR TITLE
Misc GitHub Actions workflow improvements

### DIFF
--- a/.github/workflows/gen-whoami-table.yml
+++ b/.github/workflows/gen-whoami-table.yml
@@ -28,16 +28,16 @@ jobs:
 
       - name: Run gen-whoami-table.py
         run: |
-                  uv run .github/workflows/gen-whoami-table.py ./whoami.yml
+          uv run .github/workflows/gen-whoami-table.py ./whoami.yml
 
       - name: Commit changes
         run: |
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git add whoami.md
-            if ! git diff --cached --quiet; then
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add whoami.md
+          if ! git diff --cached --quiet; then
             git commit -m "Update device WhoAmI table"
             git push
-            else
+          else
             echo "No changes to commit."
-            fi
+          fi

--- a/.github/workflows/gen-whoami-table.yml
+++ b/.github/workflows/gen-whoami-table.yml
@@ -12,17 +12,24 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      # Needed to push changes
+      contents: write
     steps:
-      - name: Checkout main
-        uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
-            python-version: '3.12'
+          python-version: '3.12'
+          enable-cache: true
+          cache-dependency-glob: .github/workflows/gen-whoami-table.py
+
       - name: Run gen-whoami-table.py
         run: |
                   uv run .github/workflows/gen-whoami-table.py ./whoami.yml
+
       - name: Commit changes
         run: |
             git config user.name "github-actions[bot]"
@@ -30,10 +37,7 @@ jobs:
             git add whoami.md
             if ! git diff --cached --quiet; then
             git commit -m "Update device WhoAmI table"
-            git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
             git push
             else
             echo "No changes to commit."
             fi
-        env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gen-whoami-table.yml
+++ b/.github/workflows/gen-whoami-table.yml
@@ -3,11 +3,10 @@ name: "Regenerate WhoAmI table"
 
 on:
   workflow_dispatch:
+  pull_request:
   push:
     paths:
       - 'whoami.yml'
-    branches:
-      - main
 
 jobs:
   build:
@@ -30,7 +29,12 @@ jobs:
         run: |
           uv run .github/workflows/gen-whoami-table.py ./whoami.yml
 
+      - name: Output generated table to actions summary
+        run: |
+          cat whoami.md >> $GITHUB_STEP_SUMMARY
+
       - name: Commit changes
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
* Removed unnecessary GitHub token, asserted the `contents` write permission instead
* Fixed `setup-uv` cache configuration
* Bumped action versions (since I had to test everything anyway)
* Tidied up indentation
* Made workflow useful for pull requests
  * In particular, the generated table is now written to step summary output ([Example](https://github.com/NgrDavid/whoami/actions/runs/14648691737))
  * The table is now only ever pushed when the workflow ran explicitly on `main` (rather than relying on the branch filter.)