### PR TITLE
Reserve Hobgoblin device

### DIFF
--- a/whoami.yml
+++ b/whoami.yml
@@ -3,14 +3,19 @@
 # yaml-language-server: $schema=./whoami.json
 
 devices:
+  123: &harptechdevice
+    name: Hobgoblin
+    authors: harp-tech
+    copyright: harp-tech
+    repositoryUrl: https://github.com/harp-tech/device.hobgoblin
+    projectUrl: https://github.com/harp-tech/device.hobgoblin
   256:
     name: USBHub
   1024:
     name: Poke
-  1040: &harptechdevice
+  1040:
+    <<: *harptechdevice
     name: MultiPwmGenerator
-    authors: harp-tech
-    copyright: harp-tech
     repositoryUrl: https://github.com/harp-tech/device.multipwm
     projectUrl: https://github.com/harp-tech/device.multipwm
   1056:


### PR DESCRIPTION
This PR reserves the WhoAmI for the Hobgoblin device.

The Hobgoblin is a simple multi-purpose device built on the Harp `core.pico` with a special focus on learning the basics of the Harp standard. The goal is to provide an extremely affordable and accessible board to be used in courses and as an overall introduction to Harp and Bonsai as discussed in https://github.com/orgs/harp-tech/discussions/108.

The reason why the WhoAmI is reserved in the smallest byte range (< 256) is to possibly allow in the future a differentiated validation for devices such as this one who are explicitly expected to be heavily modified and polymorphic (i.e. having multiple `device.yml` specifications). I will clarify better what I mean with this differentiated validation in a separate proposal.

No need to merge now, but I wanted to open the PR so that people are aware of the idea re. this WhoAmI range.