### PR TITLE
Reserve current driver and laser controller device WhoAmI

### DIFF
--- a/whoami.yml
+++ b/whoami.yml
@@ -135,6 +135,12 @@ devices:
     name: SyringePump
     repositoryUrl: https://github.com/harp-tech/device.syringepump
     projectUrl: https://github.com/harp-tech/device.syringepump
+  1298:
+    name: LaserDriverController
+    authors: ChampalimaudFoundation
+    copyright: ChampalimaudFoundation
+    repositoryUrl: https://github.com/fchampalimaud/device.laserdrivercontroller
+    projectUrl: https://github.com/fchampalimaud/device.laserdrivercontroller
   2064:
     name: NeurophotometricsFP3002
     copyright: Neurophotometrics

--- a/whoami.yml
+++ b/whoami.yml
@@ -124,6 +124,12 @@ devices:
     name: SoundCard
     repositoryUrl: https://github.com/harp-tech/device.soundcard
     projectUrl: https://github.com/harp-tech/device.soundcard
+  1282:
+    name: CurrentDriver
+    authors: ChampalimaudFoundation
+    copyright: ChampalimaudFoundation
+    repositoryUrl: https://github.com/fchampalimaud/device.currentdriver
+    projectUrl: https://github.com/fchampalimaud/device.currentdriver
   1296:
     <<: *harptechdevice
     name: SyringePump


### PR DESCRIPTION
This PR reserves the WhoAmI for new Harp device boards:

Current Driver:
This is a two channel current driver, designed to drive currents up to 1A. It can be used in optogenetics stimulations, either by directly driving the current of the LED, either by controlling the LED driver through the DAC analog voltage. This board is still in development with some hardware fixes to be done.

Laser Driver Controller:
This is a controller board for a laser, that includes frequency selection, power management, power-up and control of two SPAD modules.