### PR TITLE
Update whoami with with laser controller device

### DIFF
--- a/whoami.yml
+++ b/whoami.yml
@@ -129,6 +129,12 @@ devices:
     name: SyringePump
     repositoryUrl: https://github.com/harp-tech/device.syringepump
     projectUrl: https://github.com/harp-tech/device.syringepump
+  1298:
+    name: LaserDriverController
+    authors: ChampalimaudFoundation
+    copyright: ChampalimaudFoundation
+    repositoryUrl: https://github.com/fchampalimaud/device.laserdrivercontroller
+    projectUrl: https://github.com/fchampalimaud/device.laserdrivercontroller
   2064:
     name: NeurophotometricsFP3002
     copyright: Neurophotometrics


### PR DESCRIPTION
This PR reserves the WhoAmI for new Harp device board:

Laser Driver Controller:
This is a controller board for a laser, that includes frequency selection, power management, power-up and control of two SPAD modules.